### PR TITLE
Fix: Add missing .gitmodules file for Netlify build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "suna"]
+	path = suna
+	url = https://github.com/yethikrishna/suna.git


### PR DESCRIPTION
Netlify build was failing due to a missing .gitmodules file and submodule URL for 'suna'. This commit adds the .gitmodules file with the necessary configuration.